### PR TITLE
optimize the response body

### DIFF
--- a/src/main/java/com/geekstudy/orange/apiResponse/ResponseControllerAdvice.java
+++ b/src/main/java/com/geekstudy/orange/apiResponse/ResponseControllerAdvice.java
@@ -1,0 +1,37 @@
+package com.geekstudy.orange.apiResponse;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.geekstudy.orange.ogException.APIException;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice(basePackages = "com.geekstudy.orange.controller")
+public class ResponseControllerAdvice implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class aClass) {
+        // 如果接口返回的类型本身就是ResultVO那就没有必要进行额外的操作，返回false
+        return !returnType.getParameterType().equals(OgResult.class);
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object data, MethodParameter returnType, MediaType mediaType, Class aClass, ServerHttpRequest serverHttpRequest, ServerHttpResponse serverHttpResponse) {
+        // String类型不能直接包装，所以要进行些特别的处理
+        if (returnType.getGenericParameterType().equals(String.class)) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            try {
+                // 将数据包装在OgResult里后，再转换为json字符串响应给前端
+                return objectMapper.writeValueAsString(new OgResult<>(data));
+            } catch (JsonProcessingException e) {
+                throw new APIException("返回String类型错误");
+            }
+        }
+        // 将原本的数据包装在ResultVO里
+        return new OgResult<>(data);
+    }
+}

--- a/src/main/java/com/geekstudy/orange/controller/v1/TeacherController.java
+++ b/src/main/java/com/geekstudy/orange/controller/v1/TeacherController.java
@@ -1,6 +1,5 @@
 package com.geekstudy.orange.controller.v1;
 
-import com.geekstudy.orange.apiResponse.OgResult;
 import com.geekstudy.orange.db.model.GeekTeacher;
 import com.geekstudy.orange.service.teacher.TeacherService;
 import io.swagger.annotations.Api;
@@ -22,25 +21,25 @@ public class TeacherController {
 
     @ApiOperation(value = "add new teacher", notes = "add new teacher")
     @PostMapping(value = "addTeacher", produces = MediaType.APPLICATION_JSON_VALUE)
-    public OgResult<String> addTeacher(@RequestBody @Valid GeekTeacher geekTeacher) {
+    public String addTeacher(@RequestBody @Valid GeekTeacher geekTeacher) {
         return teacherService.addTeacher(geekTeacher);
     }
 
     @ApiOperation(value = "query teacher info")
     @GetMapping(value = "{teacherId}")
-    public OgResult<GeekTeacher> queryTeacher(@PathVariable int teacherId) {
+    public GeekTeacher queryTeacher(@PathVariable int teacherId) {
         return teacherService.queryTeacher(teacherId);
     }
 
     @ApiOperation(value = "delete teacher info")
     @DeleteMapping(value = "{teacherId}")
-    public OgResult<String> deleteTeacher(@PathVariable int teacherId) {
+    public String deleteTeacher(@PathVariable int teacherId) {
         return teacherService.deleteTeacher(teacherId);
     }
 
     @ApiOperation(value = "update teacher info")
     @PutMapping(value = "{teacherId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public OgResult<String> updateTeacher(@PathVariable int teacherId, @RequestBody GeekTeacher geekTeacher) {
+    public String updateTeacher(@PathVariable int teacherId, @RequestBody @Valid GeekTeacher geekTeacher) {
         geekTeacher.setTeacherId(teacherId);
         return teacherService.updateTeacher(geekTeacher);
     }

--- a/src/main/java/com/geekstudy/orange/service/teacher/TeacherService.java
+++ b/src/main/java/com/geekstudy/orange/service/teacher/TeacherService.java
@@ -4,8 +4,8 @@ import com.geekstudy.orange.apiResponse.OgResult;
 import com.geekstudy.orange.db.model.GeekTeacher;
 
 public interface TeacherService {
-    public OgResult<String> addTeacher(GeekTeacher geekTeacher);
-    public OgResult<GeekTeacher> queryTeacher(int teacherId);
-    public OgResult<String> deleteTeacher(int teacherId);
-    public OgResult<String> updateTeacher(GeekTeacher geekTeacher);
+    public String addTeacher(GeekTeacher geekTeacher);
+    public GeekTeacher queryTeacher(int teacherId);
+    public String deleteTeacher(int teacherId);
+    public String updateTeacher(GeekTeacher geekTeacher);
 }

--- a/src/main/java/com/geekstudy/orange/service/teacher/impl/TeacherServiceImpl.java
+++ b/src/main/java/com/geekstudy/orange/service/teacher/impl/TeacherServiceImpl.java
@@ -16,29 +16,28 @@ public class TeacherServiceImpl implements TeacherService {
     private GeekTeacherMapper geekTeacherMapper;
 
     @Override
-    public OgResult<String> addTeacher(GeekTeacher geekTeacher) {
+    public String addTeacher(GeekTeacher geekTeacher) {
         geekTeacher.setTeacherCreatetime(LocalDate.now());
         int res = geekTeacherMapper.insert(geekTeacher);
-        return res > 0 ? new OgResult<>("添加成功！") : new OgResult<>("添加失败！");
+        return res > 0 ? "添加成功！" : "添加失败！";
     }
 
     @Override
-    public OgResult<GeekTeacher> queryTeacher(int teacherId) {
-        GeekTeacher geekTeacher = geekTeacherMapper.selectByPrimaryKey(teacherId);
-        return new OgResult<>(geekTeacher);
+    public GeekTeacher queryTeacher(int teacherId) {
+        return geekTeacherMapper.selectByPrimaryKey(teacherId);
     }
 
     @Override
-    public OgResult<String> deleteTeacher(int teacherId) {
+    public String deleteTeacher(int teacherId) {
         int res = geekTeacherMapper.deleteByPrimaryKey(teacherId);
-        return res > 0 ? new OgResult<>("删除成功！") : new OgResult<>("删除失败！");
+        return res > 0 ? "删除成功！" : "删除失败！";
     }
 
     @Override
-    public OgResult<String> updateTeacher(GeekTeacher geekTeacher) {
+    public String updateTeacher(GeekTeacher geekTeacher) {
         LocalDate date = geekTeacherMapper.selectByPrimaryKey(geekTeacher.getTeacherId()).getTeacherCreatetime();
         geekTeacher.setTeacherCreatetime(date);
         int res = geekTeacherMapper.updateByPrimaryKey(geekTeacher);
-        return res > 0 ? new OgResult<>("信息更新成功！") : new OgResult<>("信息更新失败！");
+        return res > 0 ? "信息更新成功！" : "信息更新失败！";
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/33518125/84113971-21446680-aa5e-11ea-8cf2-f30580afc060.png)

> https://www.jianshu.com/p/b5b8613769db

1. 接口返回统一响应体 + 异常也返回统一响应体，其实这样已经很好了，但还是有可以优化的地方。要知道一个项目下来定义的接口搞个几百个太正常不过了，要是每一个接口返回数据时都要用响应体来包装一下好像有点麻烦，有没有办法省去这个包装过程呢？当然是有滴，还是要用到全局处理。

2. 首先，先创建一个类加上注解使其成为全局处理类。然后继承ResponseBodyAdvice接口重写其中的方法，即可对我们的controller进行增强操作

3. 重写的这两个方法是用来在controller将数据进行返回前进行增强操作，supports方法要返回为true才会执行beforeBodyWrite方法，所以如果有些情况不需要进行增强操作可以在supports方法里进行判断。对返回数据进行真正的操作还是在beforeBodyWrite方法中，我们可以直接在该方法里包装数据，这样就不需要每个接口都进行数据包装了，省去了很多麻烦。
```
@RestControllerAdvice(basePackages = "com.geekstudy.orange.controller")
public class ResponseControllerAdvice implements ResponseBodyAdvice<Object> {

    @Override
    public boolean supports(MethodParameter returnType, Class aClass) {
        // 如果接口返回的类型本身就是ResultVO那就没有必要进行额外的操作，返回false
        return !returnType.getParameterType().equals(OgResult.class);
    }

    @Override
    public Object beforeBodyWrite(Object data, MethodParameter returnType, MediaType mediaType, Class aClass, ServerHttpRequest serverHttpRequest, ServerHttpResponse serverHttpResponse) {
        // String类型不能直接包装，所以要进行些特别的处理
        if (returnType.getGenericParameterType().equals(String.class)) {
            ObjectMapper objectMapper = new ObjectMapper();
            try {
                // 将数据包装在OgResult里后，再转换为json字符串响应给前端
                return objectMapper.writeValueAsString(new OgResult<>(data));
            } catch (JsonProcessingException e) {
                throw new APIException("返回String类型错误");
            }
        }
        // 将原本的数据包装在OgResult里
        return new OgResult<>(data);
    }
}
```