### PR TITLE
use custom annotation to control response body flexibly

### DIFF
--- a/src/main/java/com/geekstudy/orange/annotation/NoResponseBody.java
+++ b/src/main/java/com/geekstudy/orange/annotation/NoResponseBody.java
@@ -1,0 +1,14 @@
+package com.geekstudy.orange.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * description:自定义注解，在controller的方法上添加此注解，将直接返回请求体，不做包装
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})//表明该注解只能放在方法上
+public @interface NoResponseBody {
+}

--- a/src/main/java/com/geekstudy/orange/apiResponse/ResponseControllerAdvice.java
+++ b/src/main/java/com/geekstudy/orange/apiResponse/ResponseControllerAdvice.java
@@ -2,6 +2,7 @@ package com.geekstudy.orange.apiResponse;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.geekstudy.orange.annotation.NoResponseBody;
 import com.geekstudy.orange.ogException.APIException;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.MediaType;
@@ -15,8 +16,9 @@ public class ResponseControllerAdvice implements ResponseBodyAdvice<Object> {
 
     @Override
     public boolean supports(MethodParameter returnType, Class aClass) {
-        // 如果接口返回的类型本身就是ResultVO那就没有必要进行额外的操作，返回false
-        return !returnType.getParameterType().equals(OgResult.class);
+        // 如果接口返回的类型本身就是OgResult那就没有必要进行额外的操作，返回false
+        // 如果包含NoResponseBody注解，就直接返回，不做包装
+        return !(returnType.getParameterType().equals(OgResult.class) || returnType.hasMethodAnnotation(NoResponseBody.class));
     }
 
     @Override

--- a/src/main/java/com/geekstudy/orange/ogException/ExceptionControllerAdvice.java
+++ b/src/main/java/com/geekstudy/orange/ogException/ExceptionControllerAdvice.java
@@ -3,7 +3,6 @@ package com.geekstudy.orange.ogException;
 import com.geekstudy.orange.annotation.ExceptionCode;
 import com.geekstudy.orange.apiResponse.OgResult;
 import com.geekstudy.orange.apiResponse.ResultCode;
-import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/33518125/84130621-14337180-aa76-11ea-9dcf-fab8e2f4d0bc.png)
> https://www.jianshu.com/p/ecc41e873fe3
使用自定义注解来标注controller中的response响应是否要被包装，如果被`@NoResponseBody注解`标注，则直接返回，不会经过ResponseControllerAdvice包装，使规范更加灵活
```
@Override
public boolean supports(MethodParameter returnType, Class aClass) {
    // 如果接口返回的类型本身就是OgResult那就没有必要进行额外的操作，返回false
    // 如果包含NoResponseBody注解，就直接返回，不做包装
    return !(returnType.getParameterType().equals(OgResult.class) || returnType.hasMethodAnnotation(NoResponseBody.class));
}
```
```
@Retention(RetentionPolicy.RUNTIME)
@Target({ElementType.METHOD})//表明该注解只能放在方法上
public @interface NoResponseBody {}
```